### PR TITLE
Add 'project' and Hash compatibility

### DIFF
--- a/lib/mini_kanren/core.rb
+++ b/lib/mini_kanren/core.rb
@@ -45,6 +45,23 @@ module MiniKanren
             break if s.nil? }
           return s
         end
+      elsif u.instance_of?(Hash) && v.instance_of?(Hash)
+        # If not the same length then can't be equal
+        if u.length != v.length
+          return nil
+        # If both empty, trivially equal
+        elsif u.empty? && v.empty?
+          return s
+        # If they don't have the same keys, can't unify
+        elsif !(u.keys.all?{|k| v.include?(k)})
+          return nil
+        # Same keys, so each value must unify
+        else
+          u.each { |key, val|
+            unify(val, v[key], s)
+            break if s.nil? }
+          return s
+        end
       elsif u == v
         s
       else
@@ -72,6 +89,12 @@ module MiniKanren
       elsif v.instance_of?(Array)
         r = v.find { |vv| occurs_check(x, vv, s) == true }
         !r.nil?
+      elsif v.instance_of?(Hash)
+        check = false
+        v.each { |key, vv|
+          check = occurs_check(x, vv, s)
+          break if check}
+        return check
       else
         false
       end
@@ -90,6 +113,9 @@ module MiniKanren
       elsif v.instance_of?(Array) && v.length
         v.each { |v| s = reify_s(v, s) }
         s
+      elsif v.instance_of?(Hash) && !v.empty?
+        v.each { |key, val| s = reify_s(val, s) }
+        s
       else
         s
       end
@@ -105,6 +131,10 @@ module MiniKanren
 
       if v.instance_of?(Array)
         v.map { |v| walk_all(v, s) }
+      elsif v.instance_of?(Hash)
+        Hash[(
+          v.map { |key, val| [key, walk_all(val, s)] }
+        )]
       else
         v
       end

--- a/lib/mini_kanren/core.rb
+++ b/lib/mini_kanren/core.rb
@@ -184,6 +184,15 @@ module MiniKanren
       lambda { |s| lambda { mplus_all(goals, s) } }
     end
 
+    # project(x, lambda { |x| eq(q, x + x) })
+    def project(u, block)
+      lambda do |s|
+        walked_u = walk_all(u, s)
+        g = block.call(walked_u)
+        g.call(s)
+      end
+    end
+
     def defer(func, *args)
       if func.arity >= 0
         fixed_arity = func.arity
@@ -256,4 +265,3 @@ module MiniKanren
 end
 extend MiniKanren::Core
 Kernel.send(:include, MiniKanren::Core)
-

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -160,6 +160,70 @@ describe "Core" do
     end
   end
 
+  it "hash" do
+    MiniKanren.exec do
+      h1 = {}
+      h2 = {}
+      q = fresh
+      run(q, eq(h1, h2)).should == ["_.0"]
+
+      h1 = {hi: 1}
+      h2 = {hi: 1}
+      q = fresh
+      run(q, eq(h1, h2)).should == ["_.0"]
+
+      x = fresh
+      h1 = {hi: 1, you: x}
+      h2 = {hi: 1, you: x}
+      q = fresh
+      run(q, eq(h1, h2)).should == ["_.0"]
+
+      h1 = {hi: 1, you: fresh}
+      h2 = {hi: 1, you: fresh}
+      q = fresh
+      run(q, eq(h1, h2)).should == ["_.0"]
+
+      x,y = fresh(2)
+      h1 = {hi: 1, you: x}
+      h2 = {hi: 1, you: y}
+      q = fresh
+      run(q, eq(h1, h2)).should == ["_.0"]
+
+      x,y = fresh(2)
+      h1 = {hi: 1, you: x}
+      h2 = {hi: 1, you: y}
+      q = fresh
+      run(q, eq(h1, h2), eq(x, 2)).should == ["_.0"]
+
+      x,y = fresh(2)
+      h1 = {hi: 1, you: x}
+      h2 = {hi: 1, you: y}
+      q = fresh
+      run(q, eq(q, h1), eq(h1, h2), eq(x, 2)).should == [{hi: 1, you: 2}]
+
+      h1 = {hi: 1, you: fresh}
+      h2 = {hi: 1, you: fresh}
+      q = fresh
+      run(q, eq(q, h1), eq(h1, h2), eq(h1[:you], 3)).should == [{hi: 1, you: 3}]
+
+      h1 = {hi: 1, you: [fresh, "peas"]}
+      h2 = {hi: 1, you: ["sweetcorn", fresh]}
+      q = fresh
+      run(q, eq(q, h1), eq(h1, h2)).should == [{hi: 1, you: ["sweetcorn", "peas"]}]
+
+      h1 = {hi: 1, you: {fruit: fresh, veg: "peas"}}
+      h2 = {hi: 1, you: {fruit: "apple", veg: fresh}}
+      q = fresh
+      run(q, eq(q, h1), eq(h1, h2)).should == [{hi: 1, you: {fruit: "apple", veg: "peas"}}]
+
+      h1 = {hi: 1, you: fresh}
+      h2 = {hi: 1, you: {fruit: "apple", veg: fresh}}
+      q = fresh
+      run(q, eq(q, h1), eq(h1, h2)).should == [{hi: 1, you: {fruit: "apple", veg: "_.0"}}]
+
+    end
+  end
+
   it "extensions" do
     MiniKanren.exec do
       q = fresh

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -52,84 +52,84 @@ describe "Core" do
       run(q, eq(x == q, q)).should == [false]
 
       run(q, conde(all(fail, succeed),
-                   all(succeed, fail))).should == []
+      all(succeed, fail))).should == []
 
       run(q, conde(all(fail, fail),
-                   all(succeed, succeed))).should == ["_.0"]
+      all(succeed, succeed))).should == ["_.0"]
 
       run(q, conde(all(succeed, succeed),
-                   all(fail, fail))).should == ["_.0"]
+      all(fail, fail))).should == ["_.0"]
 
       run(q, conde(all(eq(:olive, q), succeed),
-                   all(eq(:oil, q), succeed))).should == [:olive, :oil]
+      all(eq(:oil, q), succeed))).should == [:olive, :oil]
 
       run(1, q, conde(all(eq(:olive, q), succeed),
-                      all(eq(:oil, q), succeed))).should == [:olive]
+      all(eq(:oil, q), succeed))).should == [:olive]
 
       run(q, conde(all(eq(:virgin, q), fail),
-                   all(eq(:olive, q), succeed),
-                   all(succeed, succeed),
-                   all(eq(:oil, q), succeed))).should == [:olive, "_.0", :oil]
+      all(eq(:olive, q), succeed),
+      all(succeed, succeed),
+      all(eq(:oil, q), succeed))).should == [:olive, "_.0", :oil]
 
       run(q, conde(all(eq(:olive, q), succeed),
-                   all(succeed, succeed),
-                   all(eq(:oil, q), succeed))).should == [:olive, "_.0", :oil]
+      all(succeed, succeed),
+      all(eq(:oil, q), succeed))).should == [:olive, "_.0", :oil]
 
       run(2, q, conde(all(eq(:extra, q), succeed),
-                      all(eq(:virgin, q), fail),
-                      all(eq(:olive, q), succeed),
-                      all(eq(:oil, q), succeed))).should == [:extra, :olive]
+      all(eq(:virgin, q), fail),
+      all(eq(:olive, q), succeed),
+      all(eq(:oil, q), succeed))).should == [:extra, :olive]
 
       x = fresh
       y = fresh
       run(q, conde(all(eq(:split, x),
-                   eq(:pea, y),
-                   eq([x, y], q)))).should == [[:split, :pea]]
+      eq(:pea, y),
+      eq([x, y], q)))).should == [[:split, :pea]]
 
       run(q, all(
-                conde(
-                  all(eq(:split, x), eq(:pea, y)),
-                  all(eq(:navy, x), eq(:bean, y)))),
-                  eq([x, y], q)).should == [[:split, :pea], [:navy, :bean]]
+      conde(
+      all(eq(:split, x), eq(:pea, y)),
+      all(eq(:navy, x), eq(:bean, y)))),
+      eq([x, y], q)).should == [[:split, :pea], [:navy, :bean]]
 
       run(q, all(
-            conde(
-              all(eq(:split, x), eq(:pea, y)),
-              all(eq(:navy, x), eq(:bean, y))),
-            eq([x, y, :soup], q))).should == [[:split, :pea, :soup],
-                                              [:navy, :bean, :soup]]
+      conde(
+      all(eq(:split, x), eq(:pea, y)),
+      all(eq(:navy, x), eq(:bean, y))),
+      eq([x, y, :soup], q))).should == [[:split, :pea, :soup],
+      [:navy, :bean, :soup]]
 
       def teacupo(x)
         conde(
-          all(eq(:tea, x), succeed),
-          all(eq(:cup, x), succeed))
+        all(eq(:tea, x), succeed),
+        all(eq(:cup, x), succeed))
       end
 
       run(q, teacupo(q)).should == [:tea, :cup]
 
       run(q, all(
-            conde(
-              all(teacupo(x), eq(true, y), succeed),
-              all(eq(false, x), eq(true, y))),
-            eq([x, y], q))).should ==
-                 [[false, true], [:tea, true], [:cup, true]]
+      conde(
+      all(teacupo(x), eq(true, y), succeed),
+      all(eq(false, x), eq(true, y))),
+      eq([x, y], q))).should ==
+      [[false, true], [:tea, true], [:cup, true]]
 
       x, y, z = fresh(3)
       x_ = fresh
       run(q, all(
-            conde(
-              all(eq(y, x), eq(z, x_)),
-              all(eq(y, x_), eq(z, x))),
-            eq([y, z], q))).should ==
-                   [["_.0", "_.1"], ["_.0", "_.1"]]
+      conde(
+      all(eq(y, x), eq(z, x_)),
+      all(eq(y, x_), eq(z, x))),
+      eq([y, z], q))).should ==
+      [["_.0", "_.1"], ["_.0", "_.1"]]
 
       run(q, all(
-            conde(
-              all(eq(y, x), eq(z, x_)),
-              all(eq(y, x_), eq(z, x))),
-            eq(false, x),
-            eq([y, z], q))).should ==
-       [[false, "_.0"], ["_.0", false]]
+      conde(
+      all(eq(y, x), eq(z, x_)),
+      all(eq(y, x_), eq(z, x))),
+      eq(false, x),
+      eq([y, z], q))).should ==
+      [[false, "_.0"], ["_.0", false]]
 
       a = eq(true, q)
       b = eq(false, q)
@@ -137,8 +137,8 @@ describe "Core" do
 
       x = fresh
       b = all(
-            eq(x, q),
-            eq(false, x))
+      eq(x, q),
+      eq(false, x))
       run(q, b).should == [false]
 
       x, y = fresh(2)
@@ -157,6 +157,21 @@ describe "Core" do
 
       run(q, all(eq(x,5), project(x, lambda { |x| eq(q, x + x) }))).should == [10]
       run(q, all(eq(x,"Hello"), project(x, lambda { |x| eq(q, x + x) }))).should == ["HelloHello"]
+
+      s = {one: 1, two: fresh}
+      q = fresh
+      run(q, eq(q, s), project(s, lambda { |s| eq(s,s) })).should == [{one: 1, two: "_.0"}]
+
+      bar = {notes: [{note: fresh}, {note: fresh}]}
+      q = fresh
+      run(q,
+      eq(q, bar),
+      eq(bar[:notes][0][:note], 1),
+      eq(bar[:notes][1][:note], 1),
+      project(bar, lambda { |x| eq(x[:notes][0][:note] + x[:notes][1][:note], 2) })).should == [{notes: [{note: 1}, {note: 1}]}]
+
+      option, q = fresh(2)
+      run(q, eq(q, option), conde(eq(option, 0), eq(option, 1)), project(option, lambda { |option| eq(option + 1, 1) })).should == [0]
     end
   end
 
@@ -257,18 +272,18 @@ describe "Core" do
       def listo(l)
         d = fresh
         conde(
-          all(nullo(l), succeed),
-          all(pairo(l), cdro(l, d), defer(method(:listo), d)))
+        all(nullo(l), succeed),
+        all(pairo(l), cdro(l, d), defer(method(:listo), d)))
       end
 
       run(q, listo([:a, [:b, [q, [:d, []]]]])).should == ["_.0"]
 
       run(5, q, listo([:a, [:b, [:c, q]]])).should ==
-                   [[],
-                    ["_.0", []],
-                    ["_.0", ["_.1", []]],
-                    ["_.0", ["_.1", ["_.2", []]]],
-                    ["_.0", ["_.1", ["_.2", ["_.3", []]]]]]
+      [[],
+      ["_.0", []],
+      ["_.0", ["_.1", []]],
+      ["_.0", ["_.1", ["_.2", []]]],
+      ["_.0", ["_.1", ["_.2", ["_.3", []]]]]]
 
       fresh { |q|
         run(q, fresh { |q| eq(q, false) }).should == ["_.0"]

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -151,6 +151,15 @@ describe "Core" do
     end
   end
 
+  it "project()" do
+    MiniKanren.exec do
+      q, x = fresh(2)
+
+      run(q, all(eq(x,5), project(x, lambda { |x| eq(q, x + x) }))).should == [10]
+      run(q, all(eq(x,"Hello"), project(x, lambda { |x| eq(q, x + x) }))).should == ["HelloHello"]
+    end
+  end
+
   it "extensions" do
     MiniKanren.exec do
       q = fresh


### PR DESCRIPTION
This version now contains a 'project' function which is a new constraint that finds the value of the specified variable in the current substitution, before allowing you to specify some constraint on it. I have also modified it so that hash maps are recursively unified just like arrays. A few tests have been added for each of these things.
